### PR TITLE
Fix for new bincode versions and serde_derive.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,11 @@ license = "MIT"
 itertools = "0.*.*"
 rand = "0.*.*"
 bincode = "0.*.*"
-serde = "0.*.*"
-serde_macros = "0.*.*"
+serde_derive = "1.*.*"
 bus = "1.*.*"
 time = "0.*.*"
 sha1 = "0.*.*"
+
+[dependencies.serde]
+version = "1.*.*"
+features = ["rc"]

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -1,7 +1,7 @@
 use std::result;
 use std::io;
 use std::fmt;
-use bincode::serde;
+use bincode;
 use std::error::Error;
 
 /// Subotai error type. It reports the various ways in which a hash table query may fail.
@@ -21,7 +21,7 @@ pub enum SubotaiError {
    /// The network is unresponsive (several RPCs have timed out).
    UnresponsiveNetwork,
    Io(io::Error),
-   Deserialize(serde::DeserializeError),
+   Deserialize(bincode::Error),
 }
 
 /// Custom result type over `SubotaiError`.
@@ -71,8 +71,8 @@ impl From<io::Error> for SubotaiError {
    }
 }
 
-impl From<serde::DeserializeError> for SubotaiError {
-   fn from(err: serde::DeserializeError) -> SubotaiError {
+impl From<bincode::Error> for SubotaiError {
+   fn from(err: bincode::Error) -> SubotaiError {
       SubotaiError::Deserialize(err)
    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,8 +23,9 @@
 //!
 //! Subotai also supports caching to balance intense traffic around a given key.
 #![allow(dead_code, unknown_lints, wrong_self_convention)]
-#![feature(custom_derive, plugin)]
-#![plugin(serde_macros)]
+
+#[macro_use]
+extern crate serde_derive;
 
 extern crate itertools;
 extern crate rand;

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -3,7 +3,6 @@
 //! Subotai RPCs are the packets sent over TCP between nodes. They
 //! contain information about the sender, as well as an optional payload.
 
-use bincode::serde;
 use {routing, bincode, node, storage, time};
 use std::sync::Arc;
 use hash::SubotaiHash;
@@ -93,12 +92,12 @@ impl Rpc {
 
    /// Serializes an RPC to be send over TCP. 
    pub fn serialize(&self) -> Vec<u8> {
-       serde::serialize(&self, bincode::SizeLimit::Bounded(node::SOCKET_BUFFER_SIZE_BYTES as u64)).unwrap()
+       bincode::serialize(&self, bincode::Bounded(node::SOCKET_BUFFER_SIZE_BYTES as u64)).unwrap()
    }
 
    /// Deserializes into an RPC structure.
-   pub fn deserialize(serialized: &[u8]) -> serde::DeserializeResult<Rpc> {
-       serde::deserialize(serialized)
+   pub fn deserialize(serialized: &[u8]) -> bincode::Result<Rpc> {
+       bincode::deserialize(serialized)
    }
 
    /// Reports whether the RPC is a LocateResponse that found


### PR DESCRIPTION
I was getting compilation errors on rustc 1.22.1. Found that bincode had slightly changed its API and that serde_macros had been replaced with serde_derive.